### PR TITLE
Use QR decomposition for GLS estimates of beta

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,25 @@
 -----
 
 
-# Changes in version 2.7.0
+# Changes in version 2.7.0  (OR SHOULD THIS BE 3.0.0 ???)
+
+## Parameter estimation criteria
+
+* `stk_param_relik.m`: the old syntax for computing the gradient of
+   the restricted likelihood function:
+
+        [C, COVPARAM_DIFF, LNV_DIFF] = stk_param_relik (...)
+
+  is deprecated.  Instead, use:
+
+        [C, C_GRAD] = crit (...)
+
+  to obtain the full gradient with respect to all optimizable
+  parameters of the model.  (Note the change of behaviour for the
+  syntax with two output arguments, if the model has optimizable
+  parameters in the noise model, for instance.)
+
+* `stk_param_proflik`: NEW
 
 ## Prediction
 

--- a/covfcs/stk_nullcov.m
+++ b/covfcs/stk_nullcov.m
@@ -1,8 +1,10 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_NULLCOV ...
+%
+% FIXME: Document me!
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +28,25 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function K = stk_nullcov (param, x1, x2, diff, pairwise)  %#ok<INUSL>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+% Number of evaluations points
+n1 = size (x1, 1);
+if (nargin > 2) && (~ isempty (x2))
+    n2 = size (x2, 1);
+else
+    n2 = n1;
+end
+
+% Default value for 'pairwise' (arg #5): false
+pairwise = (nargin > 4) && pairwise;
+assert ((n1 == n2) || (~ pairwise));
+
+% Return a matrix of zeros
+if pairwise
+    K = zeros (n1, 1);
+else
+    K = zeros (n1, n2);
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/cat.m
+++ b/lm/@stk_lm_/cat.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% CAT [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function varargout = cat (dim, varargin)  %#ok<STOUT,INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+stk_error (['Arrays of linear model objects are not supported. ', ...
+    'Use cell arrays instead.'], 'IllegalOperation');
+
+% FIXME: Implement horizontal concatenation, which makes sense
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/disp.m
+++ b/lm/@stk_lm_/disp.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% DISP [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function disp (lm)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+fprintf ('<%s>\n', stk_sprintf_sizetype (lm));
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/horzcat.m
+++ b/lm/@stk_lm_/horzcat.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% HORZCAT [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function varargout = horzcat (varargin)  %#ok<STOUT>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+stk_error (['Arrays of linear model objects are not supported. ', ...
+    'Use cell arrays instead.'], 'IllegalOperation');
+
+% FIXME: Implement horizontal concatenation, which makes sense
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_covmat_noise.m
+++ b/lm/@stk_lm_/stk_covmat_noise.m
@@ -2,7 +2,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function K = stk_covmat_noise (varargin)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+K = stk_nullcov (varargin{:});
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_get_optimizable_parameters.m
+++ b/lm/@stk_lm_/stk_get_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_GET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,18 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function value = stk_get_optimizable_parameters (model) %#ok<STOUT,INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if isa (lm, 'stk_lm_')
+    
+    stk_error (['Classes derived from stk_lm_ must ' ...
+        'implement stk_get_optimizable_parameters.'], ...
+        'IncompleteClassImplementation');
+    
+else
+    
+    stk_error ('Syntax error', 'SyntaxError');
+    
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_isnoisy.m
+++ b/lm/@stk_lm_/stk_isnoisy.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_ISNOISY [overload STK funcion]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function b = stk_isnoisy (model)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+b = false;
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_lm_.m
+++ b/lm/@stk_lm_/stk_lm_.m
@@ -1,8 +1,11 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_ [internal]
+%
+% Base class for all lm objects.
+%
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +29,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_lm_ ()
 
-K = stk_covmat_noise (model.prior, varargin{:});
+lm = class (struct (), 'stk_lm_', stk_model_ ());
 
 end % function
 
-%#ok<*INUSD,*STOUT>
+
+%!test stk_test_class ('stk_lm_')

--- a/lm/@stk_lm_/stk_lm_diff.m
+++ b/lm/@stk_lm_/stk_lm_diff.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_DIFF [overloas STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,17 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [V, lm] = stk_lm_diff (lm, x, diff)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if isa (lm, 'stk_lm_')
+    
+    stk_error (['Classes derived from stk_lm_ must ' ...
+        'implement stk_lm_diff.'], 'IncompleteClassImplementation');
+    
+else
+    
+    stk_error ('Syntax error', 'SyntaxError');
+    
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_param_getdefaultbounds.m
+++ b/lm/@stk_lm_/stk_param_getdefaultbounds.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_PARAM_GETDEFAULTBOUNDS [overload STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,19 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [lb, ub] = stk_param_getdefaultbounds ...
+    (model, xi, zi)  %#ok<STOUT,INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if isa (lm, 'stk_lm_')
+    
+    stk_error (['Classes derived from stk_lm_ must ' ...
+        'implement stk_param_getdefaultbounds.'], ...
+        'IncompleteClassImplementation');
+    
+else
+    
+    stk_error ('Syntax error', 'SyntaxError');
+    
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_/stk_set_optimizable_parameters.m
+++ b/lm/@stk_lm_/stk_set_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_SET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,18 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_set_optimizable_parameters (lm, value)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if isa (lm, 'stk_lm_')
+    
+    stk_error (['Classes derived from stk_lm_ must ' ...
+        'implement stk_set_optimizable_parameters.'], ...
+        'IncompleteClassImplementation');
+    
+else
+    
+    stk_error ('Syntax error', 'SyntaxError');
+    
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_affine/stk_lm_affine.m
+++ b/lm/@stk_lm_affine/stk_lm_affine.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_affine ()
 
-lm = class (struct (), 'stk_lm_affine');
+lm = class (struct (), 'stk_lm_affine', stk_lm_noparam_ ());
 
 end  % function stk_lm_affine
 

--- a/lm/@stk_lm_constant/stk_lm_constant.m
+++ b/lm/@stk_lm_constant/stk_lm_constant.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_constant ()
 
-lm = class (struct (), 'stk_lm_constant');
+lm = class (struct (), 'stk_lm_constant', stk_lm_noparam_ ());
 
 end % function
 

--- a/lm/@stk_lm_cubic/stk_lm_cubic.m
+++ b/lm/@stk_lm_cubic/stk_lm_cubic.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_cubic ()
 
-lm = class (struct (), 'stk_lm_cubic');
+lm = class (struct (), 'stk_lm_cubic', stk_lm_noparam_ ());
 
 end % function
 

--- a/lm/@stk_lm_matrix/stk_lm_matrix.m
+++ b/lm/@stk_lm_matrix/stk_lm_matrix.m
@@ -8,7 +8,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -41,7 +41,7 @@ else
     lm = struct ('data', data);
 end
 
-lm = class (lm, 'stk_lm_matrix');
+lm = class (lm, 'stk_lm_matrix', stk_lm_noparam_ ());
 
 end % function
 

--- a/lm/@stk_lm_noparam_/stk_get_optimizable_parameters.m
+++ b/lm/@stk_lm_noparam_/stk_get_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_GET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function value = stk_get_optimizable_parameters (lm)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+value = [];
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_noparam_/stk_lm_diff.m
+++ b/lm/@stk_lm_noparam_/stk_lm_diff.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_DIFF [overload STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,17 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [V, lm] = stk_lm_diff (lm, x, diff)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if isa (lm, 'stk_lm_noparam_')
+    
+    stk_error (['stk_lm_diff cannot be used on linear model objects ' ...
+        'that they have no hyper-parameters'], 'InvalidArgument');
+        
+else
+    
+    stk_error ('Syntax error', 'SyntaxError');
+    
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_noparam_/stk_lm_noparam_.m
+++ b/lm/@stk_lm_noparam_/stk_lm_noparam_.m
@@ -1,8 +1,11 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_NOPARAM_ [internal]
+%
+% Base class for linear model objects w/o hyper-parameters.
+%
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +29,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_lm_noparam_ ()
 
-K = stk_covmat_noise (model.prior, varargin{:});
+lm = class (struct (), 'stk_lm_noparam_', stk_lm_ ());
 
 end % function
 
-%#ok<*INUSD,*STOUT>
+
+%!test stk_test_class ('stk_lm_noparam_')

--- a/lm/@stk_lm_noparam_/stk_param_getdefaultbounds.m
+++ b/lm/@stk_lm_noparam_/stk_param_getdefaultbounds.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_PARAM_GETDEFAULTBOUNDS [overload STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,9 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [lb, ub] = stk_param_getdefaultbounds (model, xi, zi)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+lb = zeros (0, 1);
+ub = zeros (0, 1);
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_noparam_/stk_set_optimizable_parameters.m
+++ b/lm/@stk_lm_noparam_/stk_set_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_SET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_set_optimizable_parameters (lm, value)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if ~ isempty (value)
+    stk_error (sprintf (['Linear model object of class %s have no ' ...
+        'optimizable parameters.'], class (lm)), 'IncorrectArgument');
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_null/stk_lm_null.m
+++ b/lm/@stk_lm_null/stk_lm_null.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_null ()
 
-lm = class (struct (), 'stk_lm_null');
+lm = class (struct (), 'stk_lm_null', stk_lm_noparam_ ());
 
 end % function
 

--- a/lm/@stk_lm_quadratic/stk_lm_quadratic.m
+++ b/lm/@stk_lm_quadratic/stk_lm_quadratic.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_quadratic ()
 
-lm = class (struct (), 'stk_lm_quadratic');
+lm = class (struct (), 'stk_lm_quadratic', stk_lm_noparam_ ());
 
 end % function
 

--- a/lm/@stk_lm_sincos/disp.m
+++ b/lm/@stk_lm_sincos/disp.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% DISP [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2020 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,20 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function disp (lm)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+fprintf ('<%s>\n', stk_sprintf_sizetype (lm));
+
+loose_spacing = stk_disp_isloose ();
+
+if loose_spacing
+    fprintf ('|\n');
+end
+
+fprintf ('|   angular_frequency:  %.3g\n', lm.angular_frequency);
+
+if loose_spacing
+    fprintf ('|\n');
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_sincos/feval.m
+++ b/lm/@stk_lm_sincos/feval.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% FEVAL [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,12 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function z = feval (lm, x)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+x = double (x);  assert (iscolumn (x));
+
+u = lm.angular_frequency * x;
+
+z = [sin(u), cos(u)];
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_sincos/stk_get_optimizable_parameters.m
+++ b/lm/@stk_lm_sincos/stk_get_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_GET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function param = stk_get_optimizable_parameters (lm)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+param = lm.param;
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_sincos/stk_lm_diff.m
+++ b/lm/@stk_lm_sincos/stk_lm_diff.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_DIFF [overload STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,20 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [V, lm] = stk_lm_diff (lm, x, diff)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if diff == 1  % diff wrt theta = log (angular_frequency)
+    
+    u = lm.angular_frequency * x;
+    V = [u .* cos(u), - u .* sin(u)];
+    
+else
+    
+    stk_error ('Incorrect value of the diff argument', 'InvalidArgument');
+    
+end
+
+% NOTE/FIXME: We could save u, sin(u) and cos(u) at eval time
+%   (we currently this would be useless since STK would not use it)
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_sincos/stk_lm_sincos.m
+++ b/lm/@stk_lm_sincos/stk_lm_sincos.m
@@ -1,8 +1,10 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_LM_SINCOS creates a 'sin+cos' linear model object
+%
+% TODO: document me!
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +28,33 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_lm_sincos (omega, omega_lims)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+if nargin == 0
+    
+    lm = struct (                    ...
+        'angular_frequency',  1.0,   ...
+        'param',              0.0,   ...
+        'param_min',          -inf,  ...
+        'param_max',          +inf   );
+    
+else
+    
+    % FIXME: Check input size and type
+    
+    assert (omega_lims(1) <= omega_lims(2));
+    
+    lm = struct (                                   ...
+        'angular_frequency',  omega,                ...
+        'param',              log (omega),          ...
+        'param_min',          log (omega_lims(1)),  ...
+        'param_max',          log (omega_lims(2))   );
+    
+end
 
-end % function
+lm = class (lm, 'stk_lm_sincos', stk_lm_ ());
 
-%#ok<*INUSD,*STOUT>
+end  % function
+
+
+%!test stk_test_class ('stk_lm_sincos')

--- a/lm/@stk_lm_sincos/stk_param_getdefaultbounds.m
+++ b/lm/@stk_lm_sincos/stk_param_getdefaultbounds.m
@@ -1,8 +1,8 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_PARAM_GETDEFAULTBOUNDS [overload STK function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +26,9 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function [lb, ub] = stk_param_getdefaultbounds (lm, xi, zi)  %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+lb = lm.param_min;
+ub = lm.param_max;
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/@stk_lm_sincos/stk_set_optimizable_parameters.m
+++ b/lm/@stk_lm_sincos/stk_set_optimizable_parameters.m
@@ -1,8 +1,17 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_SET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that
+%    wish to experiment with parameter classes can already overload it,
+%    but should be aware that API-breaking changes are likely to happen
+%    in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +35,13 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function lm = stk_set_optimizable_parameters (lm, param)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+% FIXME: Check input size and type
+
+assert ((lm.param_min <= param) && (param <= lm.param_max));
+
+lm.param = param;
+lm.angular_frequency = exp (param);
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/lm/stk_lm_diff.m
+++ b/lm/stk_lm_diff.m
@@ -1,0 +1,63 @@
+% STK_LM_DIFF differentiates a linear model wrt hyper-parameters
+%
+% CALL: V = stk_lm_diff (LM, X, DIFF)
+%
+%    computes the partial derivative of the "design matrix" produced
+%    the linear model LM at the input points X, with respect to its
+%    DIFF-th hyper-parameter.  The result is an N-by-Q, where N is the
+%    number of input points, and Q the size of the linear model (number
+%    of basis functions).
+%
+% CALL: [V, LM] = stk_lm_diff (LM, X, DIFF)
+%
+%    also returns an updated LM object that possibly contains auxiliary
+%    results produced during the computation of the gradient.  This
+%    provides a mechanism to optimize sequences of computations of
+%    partial derivative at a given point.
+
+% Copyright Notice
+%
+%    Copyright (C) 2021 CentraleSupelec
+%
+%    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
+
+% Copying Permission Statement
+%
+%    This file is part of
+%
+%            STK: a Small (Matlab/Octave) Toolbox for Kriging
+%               (http://sourceforge.net/projects/kriging)
+%
+%    STK is free software: you can redistribute it and/or modify it under
+%    the terms of the GNU General Public License as published by the Free
+%    Software Foundation,  either version 3  of the License, or  (at your
+%    option) any later version.
+%
+%    STK is distributed  in the hope that it will  be useful, but WITHOUT
+%    ANY WARRANTY;  without even the implied  warranty of MERCHANTABILITY
+%    or FITNESS  FOR A  PARTICULAR PURPOSE.  See  the GNU  General Public
+%    License for more details.
+%
+%    You should  have received a copy  of the GNU  General Public License
+%    along with STK.  If not, see <http://www.gnu.org/licenses/>.
+
+function [V, lm] = stk_lm_diff (lm, x, diff) %#ok<INUSD>
+
+if isa (lm, 'function_handle')
+    
+    stk_error (['stk_lm_diff cannot be used on linear model objects ' ...
+        'represented by function handles, since they have no hyper-' ...
+        'parameters'], 'InvalidArgument');
+        
+else
+    
+    stk_error (sprintf (['stk_lm_diff is not implemented for models ' ...
+        'of class %s.'], class (lm)), 'NotImplemented');
+    
+end
+
+end % function
+
+
+%!error stk_lm_diff (@sin, [], 1)
+%!error stk_lm_diff (1.2, [], 1)

--- a/model/@stk_model_/stk_covmat_noise.m
+++ b/model/@stk_model_/stk_covmat_noise.m
@@ -26,11 +26,10 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, x1, x2, diff, pairwise)
+function K = stk_covmat_noise (model, x1, x2, diff, pairwise)
 
 stk_error (['Classes derived from stk_model_ must implement ' ...
     'stk_covmat_noise.'], 'IncompleteClassImplementation');
-
 
 end % function
 

--- a/model/@stk_model_/stk_get_optimizable_parameters.m
+++ b/model/@stk_model_/stk_get_optimizable_parameters.m
@@ -1,8 +1,16 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_GET_OPTIMIZABLE_PARAMETERS [overload STK function, internal]
+%
+% INTERNAL FUNCTION WARNING:
+%
+%    This function is currently considered as internal.  STK users that wish to
+%    experiment with parameter classes can already overload it, but should be
+%    aware that API-breaking changes are likely to happen in future releases.
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2018, 2020 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +34,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function value = stk_get_optimizable_parameters (model) %#ok<INUSD>
 
-K = stk_covmat_noise (model.prior, varargin{:});
+% Model objects that *do* have some optimizable parameters must
+% overload this function.
+
+value = [];
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/model/@stk_model_/stk_set_optimizable_parameters.m
+++ b/model/@stk_model_/stk_set_optimizable_parameters.m
@@ -1,8 +1,10 @@
-% STK_COVMAT_NOISE [STK internal]
+% STK_SET_OPTIMIZABLE_PARAMETERS [overload STK internal]
+%
+% See also: stk_get_optimizable_parameters
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2020 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,10 +28,14 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, varargin)
+function model = stk_set_optimizable_parameters (model, value)
 
-K = stk_covmat_noise (model.prior, varargin{:});
+% Model objects that *do* have some optimizable parameters must
+% overload this function.
+
+if ~ isempty (value)
+    stk_error (sprintf (['Model object of class %s have no ' ...
+        'optimizable parameters.'], class (model)), 'IncorrectArgument');
+end
 
 end % function
-
-%#ok<*INUSD,*STOUT>

--- a/model/noise/@stk_gaussiannoise_/stk_covmat_noise.m
+++ b/model/noise/@stk_gaussiannoise_/stk_covmat_noise.m
@@ -26,21 +26,9 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, varargin)
+function K = stk_covmat_noise (model, varargin)
 
-if nargout <= 1
-    
-    K = stk_covmat (model, varargin{:});
-    
-elseif nargout == 2
-    
-    [K, P1] = stk_covmat (model, varargin{:});
-    
-else
-    
-    [K, P1, P2] = stk_covmat (model, varargin{:});
-    
-end
+K = stk_covmat (model, varargin{:});
 
 end % function
 

--- a/model/prior_struct/stk_covmat_noise.m
+++ b/model/prior_struct/stk_covmat_noise.m
@@ -34,8 +34,19 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, x1, x2, diff, pairwise)
+function K = stk_covmat_noise (model, varargin)
 
+if stk_isnoisy (model)
+    K = stk_covmat_noise_ (model, varargin{:});
+else
+    K = stk_nullcov ([], varargin{:});
+end
+
+end % function
+
+
+function K = stk_covmat_noise_ (model, x1, x2, diff, pairwise)
+    
 % Number of evaluations points
 n1 = size (x1, 1);
 if (nargin > 2) && (~ isempty (x2))
@@ -53,7 +64,7 @@ if nargin < 4,  diff = -1;  end
 pairwise = (nargin > 4) && pairwise;
 assert ((n1 == n2) || (~ pairwise));
 
-if autocov && (diff ~= 0) && (stk_isnoisy (model))
+if autocov && (diff ~= 0)
     
     if ~ isnumeric (model.lognoisevariance)
         
@@ -123,7 +134,9 @@ else  % Return a null matrix
     % a) autocov is false: we are actually computing a *cross*-covariance matrix
     % b) diff = 0: derivative with respect to a parameter that does not modify
     %    the covariance matrix of the noise
-    % c) we are in the noiseless case.
+    
+    % TEMP: Does b) really happen?  I bet not.
+    assert (diff ~= 0);
     
     if pairwise
         K = zeros (n1, 1);
@@ -131,18 +144,6 @@ else  % Return a null matrix
         K = zeros (n1, n2);
     end
     
-end
-
-
-%% Compute matrices for the linear part
-
-% No linear part for the 'noise' output: return empty matrices if required
-if nargout > 1
-    P1 = zeros (n1, 0);
-    
-    if nargout > 2
-        P2 = zeros (n2, 0);
-    end
 end
 
 end % function
@@ -157,43 +158,36 @@ end % function
 %! x1 = stk_sampling_randunif (n1, d);
 %! x2 = stk_sampling_randunif (n2, d);
 
-%!error [KK, PP] = stk_covmat_noise ();
-%!error [KK, PP] = stk_covmat_noise (model);
+%!error KK = stk_covmat_noise ();
+%!error KK = stk_covmat_noise (model);
 
-%!test  [Ka, Pa] = stk_covmat_noise (model, x1);                           % (1)
-%!test  [K1, P1] = stk_covmat_noise (model, x1, []);
-%!test  [K2, P2] = stk_covmat_noise (model, x1, [], -1);
-%!test  [K3, P3] = stk_covmat_noise (model, x1, [], -1, false);
+%!test  Ka = stk_covmat_noise (model, x1);                           % (1)
+%!test  K1 = stk_covmat_noise (model, x1, []);
+%!test  K2 = stk_covmat_noise (model, x1, [], -1);
+%!test  K3 = stk_covmat_noise (model, x1, [], -1, false);
 %!assert (isequal (size (Ka), [n1 n1]));
-%!assert (isequal (size (Pa), [n1 0]));
-%!assert (isequal (P1, Pa) && (isequal (K1, Ka)))
-%!assert (isequal (P2, Pa) && (isequal (K2, Ka)))
-%!assert (isequal (P3, Pa) && (isequal (K3, Ka)))
+%!assert (isequal (K1, Ka))
+%!assert (isequal (K2, Ka))
+%!assert (isequal (K3, Ka))
 
-%!test  [Kb, Pb] = stk_covmat_noise (model, x1, x1);                       % (2)
-%!test  [K1, P1] = stk_covmat_noise (model, x1, x1, -1);
-%!test  [K2, P2] = stk_covmat_noise (model, x1, x1, -1, false);
+%!test  Kb = stk_covmat_noise (model, x1, x1);                       % (2)
+%!test  K1 = stk_covmat_noise (model, x1, x1, -1);
+%!test  K2 = stk_covmat_noise (model, x1, x1, -1, false);
 %!assert (isequal (size (Kb), [n1 n1]));
-%!assert (isequal (size (Pb), [n1 0]));
-%!assert (isequal (P1, Pb) && (isequal (K1, Kb)))
-%!assert (isequal (P2, Pb) && (isequal (K2, Kb)))
+%!assert (isequal (K1, Kb))
+%!assert (isequal (K2, Kb))
 
-%!test  [Kc, Pc] = stk_covmat_noise (model, x1, x2);                       % (3)
-%!test  [K1, P1] = stk_covmat_noise (model, x1, x2, -1);
-%!test  [K2, P2] = stk_covmat_noise (model, x1, x2, -1, false);
+%!test  Kc = stk_covmat_noise (model, x1, x2);                       % (3)
+%!test  K1 = stk_covmat_noise (model, x1, x2, -1);
+%!test  K2 = stk_covmat_noise (model, x1, x2, -1, false);
 %!assert (isequal (size (Kc), [n1 n2]));
-%!assert (isequal (size (Pc), [n1 0]));
-%!assert (isequal (P1, Pc) && (isequal (K1, Kc)))
-%!assert (isequal (P2, Pc) && (isequal (K2, Kc)))
+%!assert (isequal (K1, Kc))
+%!assert (isequal (K2, Kc))
 
 % In the noiseless case, (1) and (2) should give the same results
 %!assert (isequal (Kb, Ka));
 
 % In the noisy case, however...
-%!test  [Ka, Pa] = stk_covmat_noise (model2, x1);                         % (1')
-%!test  [Kb, Pb] = stk_covmat_noise (model2, x1, x1);                     % (2')
+%!test  Ka = stk_covmat_noise (model2, x1);                         % (1')
+%!test  Kb = stk_covmat_noise (model2, x1, x1);                     % (2')
 %!error assert (isequal (Kb, Ka));
-
-% The second output depends on x1 only => should be the same for (1)--(3)
-%!assert (isequal (Pa, Pb));
-%!assert (isequal (Pa, Pc));

--- a/model/prior_struct/stk_get_optimizable_model_parameters.m
+++ b/model/prior_struct/stk_get_optimizable_model_parameters.m
@@ -10,7 +10,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2017 LNE
 %
 %    Authors:  Remi Stroh   <remi.stroh@lne.fr>
@@ -39,13 +39,17 @@
 function value = stk_get_optimizable_model_parameters (model)
 
 stk_assert_model_struct (model);
+model = stk_model_fixlm (model);
 
-% Covariance parameters
+% Parameters of the linear model
+lmparam = stk_get_optimizable_parameters (model.lm);
+
+% Parameters of the covariance function
 covparam = stk_get_optimizable_parameters (model.param);
 
-% Noise parameters
+% Parameters of the noise parameters
 noiseparam = stk_get_optimizable_noise_parameters (model);
 
-value = [covparam; noiseparam];
+value = [lmparam; covparam; noiseparam];
    
 end % function

--- a/param/classes/stk_get_optimizable_parameters.m
+++ b/param/classes/stk_get_optimizable_parameters.m
@@ -62,6 +62,11 @@ if isstruct (arg1)
         
     end
     
+elseif isa (arg1, 'function_handle')
+    
+    % Function handles can be used instead of lm objects
+    value = [];
+    
 else
     
     if isnumeric (arg1)

--- a/param/estim/stk_param_estim.m
+++ b/param/estim/stk_param_estim.m
@@ -36,7 +36,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2015-2018, 2020 CentraleSupelec
+%    Copyright (C) 2015-2018, 2020, 2021 CentraleSupelec
 %    Copyright (C) 2017 LNE
 %    Copyright (C) 2014 A. Ravisankar
 %    Copyright (C) 2011-2014 SUPELEC
@@ -66,179 +66,35 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [param_opt, lnv_opt, info] = stk_param_estim ...
-    (model, xi, zi, param0, lnv0, criterion)
+function [param_opt, lnv_opt, info] = stk_param_estim (varargin)
 
-stk_assert_model_struct (model);
-% FIXME: Implement stk_param_estim for noise priors too
+% TODO (?): Remove this function entirely, use stk_param_estim_ instead,
+%           and jump to major release 3.x
 
-% Empty is the same as 'not provided'
-if nargin < 6
-    criterion = [];
-    if nargin < 5
-        lnv0 = [];
-        if nargin < 4
-            param0 = [];
-        end
-    end
+switch nargout
+    
+    case {0, 1}
+        model_opt = stk_param_estim_ (varargin{:});
+        param_opt = model_opt.param;
+        
+    case 2
+        model_opt = stk_param_estim_ (varargin{:});
+        param_opt = model_opt.param;
+        lnv_opt = model_opt.lognoisevariance;
+        
+    case 3
+        [model_opt, info] = stk_param_estim_ (varargin{:});
+        param_opt = model_opt.param;
+        lnv_opt = model_opt.lognoisevariance;
+        
+    otherwise
+        stk_error ('Too many input arguments.', 'TooManyInputArgs');
+        
 end
-
-% Size checking: xi, zi
-zi_data = double (zi);
-if ~ isequal (size (zi_data), [stk_get_sample_size(xi) 1])
-    errmsg = 'zi should be a column, with the same number of rows as xi.';
-    stk_error (errmsg, 'IncorrectSize');
-end
-
-% Warn about special case: constant response
-if (std (zi_data) == 0)
-    warning ('STK:stk_param_estim:ConstantResponse', ['Constant-response ' ...
-        'data: the output of stk_param_estim is likely to be unreliable.']);
-end
-
-% Make sure that lognoisevariance is -inf for noiseless models
-if ~ stk_isnoisy (model)
-    model.lognoisevariance = -inf;
-end
-
-% Default criterion: restricted likelihood (ReML method)
-if isempty (criterion)
-    criterion = @stk_param_relik;
-end
-
-% Make sure that we have a starting point in (param0, lnv0)
-[param0, lnv0, do_estim_lnv] = provide_starting_point (model, xi, zi, param0, lnv0);
-
-% Set the starting point
-model.param = param0;
-model.lognoisevariance = lnv0;
-
-% Get selectors
-select = stk_param_getblockselectors (model);
-covparam_select = select{1};
-noiseparam_select = select{2} & do_estim_lnv;
-
-% NOTE ABOUT SELECTOrS / NaNs
-% The situation is currently a little odd, with a focus on estimating
-% covariance hyperparameters inherited from STK's history.  More precisely:
-%  * the 'linear model' part is not allowed to have (nonlinear) hyperparameters;
-%  * the hyperparameters of the covariance function are automatically estimated
-%    (all of them), regardless of whether there are NaNs or not in model.param;
-%  * the hyperparameters of the noise variance function are estimated (all of
-%    them) if there are NaNs in the vector OR if lnv0 is provided.  Note that
-%    only the case where lnv is a numerical scalar is currently documented.
-%    Also, note that all hyperparameters are estimated, even if only some of
-%    them are NaNs.
-% FIXME: Clarify this confusing situation...
-
-% Call optimization routine
-if nargout > 2
-    [model_opt, info] = stk_param_estim_optim ...
-        (model, xi, zi, criterion, covparam_select, noiseparam_select);
-else
-    model_opt = stk_param_estim_optim ...
-        (model, xi, zi, criterion, covparam_select, noiseparam_select);
-end
-
-param_opt = model_opt.param;
-lnv_opt = model_opt.lognoisevariance;
 
 end % function
 
 %#ok<*CTCH,*LERR,*SPWRN,*WNTAG>
-
-
-function [param0, lnv0, do_estim_lnv] = provide_starting_point ...
-    (model, xi, zi, param0, lnv0)
-
-% If param0 is not empty, it means that the user has provided
-% a starting point, in which case we must use it.
-if ~ isempty (param0)
-    
-    % Test if param0 contains NaNs of Infs
-    assert_is_finite (param0, 'param0');
-    % Cast to the appropriate type
-    if isnumeric (param0)
-        param0 = stk_set_optimizable_parameters (model.param, param0);
-    end
-    
-    % Now take care of lnv0.
-    % Same rule: if not empty, we have a user-provided starting point.
-    if isempty (lnv0)
-        % When lnv0 is not provided, noise variance estimation happens when lnv has NaNs.
-        do_estim_lnv = any (isnan (stk_get_optimizable_noise_parameters (model)));
-        if do_estim_lnv
-            % We have a user-provided starting point for param0 but not for lnv0.
-            model.param = param0;
-            lnv0 = stk_param_init_lnv (model, xi, zi);
-        else
-            lnv0 = model.lognoisevariance;
-        end
-    else
-        % When lnv0 is provided, noise variance *must* be estimated
-        do_estim_lnv = true;
-        % Test if lnv0 contains NaNs of Infs
-        assert_is_finite (lnv0, 'lnv0');
-        % Cast lnv0 to a variable of the appropriate type (numeric or object)
-        lnv0 = stk_set_optimizable_parameters (model.lognoisevariance, lnv0);
-    end
-    
-else  % Otherwise, try stk_param_init to get a starting point
-    
-    if isempty (lnv0)
-        % If needed, stk_param_init will also provide a starting point for lnv0
-        % (This is triggered by the presence of NaNs.)
-        do_estim_lnv = any (isnan (stk_get_optimizable_noise_parameters (model)));
-    else
-        % When lnv0 is provided, noise variance *must* be estimated
-        do_estim_lnv = true;
-        % Test if lnv0 contains NaNs of Infs
-        assert_is_finite (lnv0, 'lnv0');        
-        % Cast to the appropriate type
-        if isnumeric (lnv0)
-            lnv0 = stk_set_optimizable_parameters (model.lognoisevariance, param0);
-        end
-        % Install lnv0 in the model
-        model.lognoisevariance = lnv0;
-    end
-    
-    [param0, lnv0] = stk_param_init (model, xi, zi);
-    
-end % if
-
-end % function
-
-
-function assert_is_finite (param, param_name)
-
-% Check that there are no NaNs or Infs
-param_ = stk_get_optimizable_parameters (param);
-if ~ all (isfinite (param_))
-    stk_error (sprintf (['Incorrect value for input argument %s.  The components ' ...
-        'of the starting point must be neither infinite nor NaN.'], param_name),   ...
-        'InvalidArgument');
-end
-
-end % function
-
-
-function select = stk_param_getblockselectors (model)
-
-stk_assert_model_struct (model);
-
-select = cell (2, 1);
-
-% Covariance parameters
-covparam = stk_get_optimizable_parameters (model.param);
-covparam_size = length (covparam);
-select{1} = true (covparam_size, 1);
-
-% Noise parameters
-noiseparam = stk_get_optimizable_noise_parameters (model);
-noiseparam_size = length (noiseparam);
-select{2} = true (noiseparam_size, 1);
-
-end % function
 
 
 %!shared f, xi, zi, NI, param0, param1, model

--- a/param/estim/stk_param_estim_.m
+++ b/param/estim/stk_param_estim_.m
@@ -103,7 +103,7 @@ select = [lmparam_select; covparam_select; noiseparam_select];
 % FIXME: Clarify this confusing situation...
 
 % Call optimization routine
-if nargout > 2
+if nargout >= 2
     [model_opt, info] = stk_param_estim_optim ...
         (model, xi, zi, criterion, select);
 else

--- a/param/estim/stk_param_estim_.m
+++ b/param/estim/stk_param_estim_.m
@@ -1,0 +1,214 @@
+% STK_PARAM_ESTIM_ [STK internal]
+%
+% This should become the new stk_param_estim (?).
+
+% Copyright Notice
+%
+%    Copyright (C) 2015-2018, 2020, 2021 CentraleSupelec
+%    Copyright (C) 2017 LNE
+%    Copyright (C) 2014 A. Ravisankar
+%    Copyright (C) 2011-2014 SUPELEC
+%
+%    Authors:  Julien Bect        <julien.bect@centralesupelec.fr>
+%              Emmanuel Vazquez   <emmanuel.vazquez@centralesupelec.fr>
+%              Ashwin Ravisankar  <ashwinr1993@gmail.com>
+%              Remi Stroh         <remi.stroh@lne.fr>
+
+% Copying Permission Statement
+%
+%    This file is part of
+%
+%            STK: a Small (Matlab/Octave) Toolbox for Kriging
+%               (http://sourceforge.net/projects/kriging)
+%
+%    STK is free software: you can redistribute it and/or modify it under
+%    the terms of the GNU General Public License as published by the Free
+%    Software Foundation,  either version 3  of the License, or  (at your
+%    option) any later version.
+%
+%    STK is distributed  in the hope that it will  be useful, but WITHOUT
+%    ANY WARRANTY;  without even the implied  warranty of MERCHANTABILITY
+%    or FITNESS  FOR A  PARTICULAR PURPOSE.  See  the GNU  General Public
+%    License for more details.
+%
+%    You should  have received a copy  of the GNU  General Public License
+%    along with STK.  If not, see <http://www.gnu.org/licenses/>.
+
+function [model_opt, info] = stk_param_estim_ ...
+    (model, xi, zi, param0, lnv0, criterion)
+
+stk_assert_model_struct (model);
+% FIXME: Implement stk_param_estim for noise priors too
+
+% Empty is the same as 'not provided'
+if nargin < 6
+    criterion = [];
+    if nargin < 5
+        lnv0 = [];
+        if nargin < 4
+            param0 = [];
+        end
+    end
+end
+
+% Size checking: xi, zi
+zi_data = double (zi);
+if ~ isequal (size (zi_data), [stk_get_sample_size(xi) 1])
+    errmsg = 'zi should be a column, with the same number of rows as xi.';
+    stk_error (errmsg, 'IncorrectSize');
+end
+
+% Warn about special case: constant response
+if (std (zi_data) == 0)
+    warning ('STK:stk_param_estim:ConstantResponse', ['Constant-response ' ...
+        'data: the output of stk_param_estim is likely to be unreliable.']);
+end
+
+% Make sure that lognoisevariance is -inf for noiseless models
+if ~ stk_isnoisy (model)
+    model.lognoisevariance = -inf;
+end
+
+% Default criterion: restricted likelihood (ReML method)
+if isempty (criterion)
+    criterion = @stk_param_relik;
+end
+
+% Make sure that we have a starting point in (param0, lnv0)
+[param0, lnv0, do_estim_lnv] = provide_starting_point (model, xi, zi, param0, lnv0);
+
+% Set the starting point
+model.param = param0;
+model.lognoisevariance = lnv0;
+
+% Get selectors
+% (this stuff is ugly, we should simplify by getting rid of do_estim_lnv)
+select = stk_param_getblockselectors (model);
+lmparam_select = select{1};
+covparam_select = select{2};
+noiseparam_select = select{3} & do_estim_lnv;
+select = [lmparam_select; covparam_select; noiseparam_select];
+
+% NOTE ABOUT SELECTOrS / NaNs
+% The situation is currently a little odd, with a focus on estimating
+% covariance hyperparameters inherited from STK's history.  More precisely:
+%  * the 'linear model' part is not allowed to have (nonlinear) hyperparameters;
+%  * the hyperparameters of the covariance function are automatically estimated
+%    (all of them), regardless of whether there are NaNs or not in model.param;
+%  * the hyperparameters of the noise variance function are estimated (all of
+%    them) if there are NaNs in the vector OR if lnv0 is provided.  Note that
+%    only the case where lnv is a numerical scalar is currently documented.
+%    Also, note that all hyperparameters are estimated, even if only some of
+%    them are NaNs.
+% FIXME: Clarify this confusing situation...
+
+% Call optimization routine
+if nargout > 2
+    [model_opt, info] = stk_param_estim_optim ...
+        (model, xi, zi, criterion, select);
+else
+    model_opt = stk_param_estim_optim ...
+        (model, xi, zi, criterion, select);
+end
+
+end % function
+
+%#ok<*CTCH,*LERR,*SPWRN,*WNTAG>
+
+
+function [param0, lnv0, do_estim_lnv] = provide_starting_point ...
+    (model, xi, zi, param0, lnv0)
+
+% If param0 is not empty, it means that the user has provided
+% a starting point, in which case we must use it.
+if ~ isempty (param0)
+    
+    % Test if param0 contains NaNs of Infs
+    assert_is_finite (param0, 'param0');
+    % Cast to the appropriate type
+    if isnumeric (param0)
+        param0 = stk_set_optimizable_parameters (model.param, param0);
+    end
+    
+    % Now take care of lnv0.
+    % Same rule: if not empty, we have a user-provided starting point.
+    if isempty (lnv0)
+        % When lnv0 is not provided, noise variance estimation happens when lnv has NaNs.
+        do_estim_lnv = any (isnan (stk_get_optimizable_noise_parameters (model)));
+        if do_estim_lnv
+            % We have a user-provided starting point for param0 but not for lnv0.
+            model.param = param0;
+            lnv0 = stk_param_init_lnv (model, xi, zi);
+        else
+            lnv0 = model.lognoisevariance;
+        end
+    else
+        % When lnv0 is provided, noise variance *must* be estimated
+        do_estim_lnv = true;
+        % Test if lnv0 contains NaNs of Infs
+        assert_is_finite (lnv0, 'lnv0');
+        % Cast lnv0 to a variable of the appropriate type (numeric or object)
+        lnv0 = stk_set_optimizable_parameters (model.lognoisevariance, lnv0);
+    end
+    
+else  % Otherwise, try stk_param_init to get a starting point
+    
+    if isempty (lnv0)
+        % If needed, stk_param_init will also provide a starting point for lnv0
+        % (This is triggered by the presence of NaNs.)
+        do_estim_lnv = any (isnan (stk_get_optimizable_noise_parameters (model)));
+    else
+        % When lnv0 is provided, noise variance *must* be estimated
+        do_estim_lnv = true;
+        % Test if lnv0 contains NaNs of Infs
+        assert_is_finite (lnv0, 'lnv0');        
+        % Cast to the appropriate type
+        if isnumeric (lnv0)
+            lnv0 = stk_set_optimizable_parameters (model.lognoisevariance, param0);
+        end
+        % Install lnv0 in the model
+        model.lognoisevariance = lnv0;
+    end
+    
+    [param0, lnv0] = stk_param_init (model, xi, zi);
+    
+end % if
+
+end % function
+
+
+function assert_is_finite (param, param_name)
+
+% Check that there are no NaNs or Infs
+param_ = stk_get_optimizable_parameters (param);
+if ~ all (isfinite (param_))
+    stk_error (sprintf (['Incorrect value for input argument %s.  The components ' ...
+        'of the starting point must be neither infinite nor NaN.'], param_name),   ...
+        'InvalidArgument');
+end
+
+end % function
+
+
+function select = stk_param_getblockselectors (model)
+
+% FIXME: This function only works for prior model structs.
+%        It does not belong here...
+
+stk_assert_model_struct (model);
+
+select = cell (3, 1);
+
+% Linear model parameters
+lmparam_size = length (stk_get_optimizable_parameters (model.lm));
+select{1} = true (lmparam_size, 1);
+
+% Covariance parameters
+covparam_size = length (stk_get_optimizable_parameters (model.param));
+select{2} = true (covparam_size, 1);
+
+% Noise parameters
+noiseparam_size = length (stk_get_optimizable_noise_parameters (model));
+select{3} = true (noiseparam_size, 1);
+
+end % function

--- a/param/estim/stk_param_gls.m
+++ b/param/estim/stk_param_gls.m
@@ -68,7 +68,8 @@ zi = double (zi);
 L = stk_cholcov (K, 'lower');
 W = linsolve (L, P, struct ('LT', true));
 u = linsolve (L, zi, struct ('LT', true));
-beta = (W' * W) \ (W' * u);
+[Q,R] = qr(W);
+beta = R\(Q'*u);
 
 if nargin > 1
     % Assuming that the actual covariance matrice is sigma^2 K, compute the

--- a/param/estim/stk_param_loopvc.m
+++ b/param/estim/stk_param_loopvc.m
@@ -2,14 +2,13 @@
 %
 % CALL: C = stk_param_loopvc (MODEL, XI, ZI)
 %
-%   computes the value C of the Leave-One-Out predictive variance criterion of
-%   MODEL given the data (XI, ZI).
+%   computes the value C of the Leave-One-Out predictive variance criterion
+%   of MODEL given the data (XI, ZI).
 %
-% CALL: [C, COVPARAM_DIFF, LNV_DIFF] = stk_param_loopvc (MODEL, XI, ZI)
+% CALL: [C, C_GRAD] = stk_param_loopvc (MODEL, XI, ZI)
 %
-%   also returns the gradient COVPARAM_DIFF of C with respect to the parameters
-%   of the covariance function, its the derivative LNV_DIFF with respect to the
-%   logarithm of the noise variance.
+%   also returns the gradient C_GRAD of C with respect to all the
+%   optimizable parameters of the model.
 %
 % REFERENCE
 %
@@ -22,7 +21,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2018 CentraleSupelec
+%    Copyright (C) 2018, 2021 CentraleSupelec
 %    Copyright (C) 2018 LNE
 %
 %    Authors:  Remi Stroh   <remi.stroh@lne.fr>
@@ -48,7 +47,7 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [C, covparam_diff, noiseparam_diff] = stk_param_loopvc (model, xi, zi)
+function [C, C_grad, C_grad_noiseparam] = stk_param_loopvc (model, xi, zi)
 
 zi = double (zi);
 
@@ -57,12 +56,6 @@ n = size (xi, 1);
 if ~ isequal (size (zi), [n 1])
     stk_error (['zi must be a column vector, with the same' ...
         'same number of rows as x_obs.'], 'IncorrectSize');
-end
-
-if nargout >= 3
-    % Parameters of the noise variance function
-    noiseparam = stk_get_optimizable_noise_parameters (model);
-    noiseparam_size = length (noiseparam);
 end
 
 
@@ -94,32 +87,56 @@ C = delta_res' * raw_res / n;
 
 if nargout >= 2
     
-    % Get numerical parameter vector from parameter object
-    covparam = stk_get_optimizable_parameters (model.param);
-    covparam_size = length (covparam);
-    covparam_diff = zeros (covparam_size, 1);
+    % Gradient wrt parameters of the linear model
+    lmparam_size = length (stk_get_optimizable_parameters (model.lm));
+    C_grad_lmparam = zeros (lmparam_size, 1);
+    if lmparam_size > 0
+        stk_error ('Not implemented yet.', 'NotImplemented');
+        % FIXME: Implement!
+    end
     
+    % Gradient wrt parameters of the covariance function
+    covparam_size = length (stk_get_optimizable_parameters (model.param));
+    C_grad_covparam = zeros (covparam_size, 1);
     for diff = 1:covparam_size
         V = feval (model.covariance_type, model.param, xi, xi, diff);
         W = R * V * R;
-        covparam_diff(diff) = (delta_res'./(n * dR')) * (diag(W) .* raw_res - 2 * W * zi);
+        C_grad_covparam(diff) = (delta_res'./(n * dR')) * (diag(W) .* raw_res - 2 * W * zi);
     end
     
-    if nargout >= 3
-        
-        if noiseparam_size == 0
-            noiseparam_diff = [];
-        else
-            noiseparam_diff = zeros (noiseparam_size, 1);
-            for diff = 1:noiseparam_size
-                V = stk_covmat_noise (model, xi, [], diff);
-                W = R * V * R;
-                noiseparam_diff(diff) = (2 * raw_res'./(n * dR')) * (diag(W) .* raw_res - W * zi);
-            end
-        end
+    % Number of parameters in the noise model
+    noiseparam_size = length (stk_get_optimizable_noise_parameters (model));
+    C_grad_noiseparam = zeros (noiseparam_size, 1);
+    for diff = 1:noiseparam_size
+        V = stk_covmat_noise (model, xi, [], diff);
+        W = R * V * R;
+        C_grad_noiseparam(diff) = (2 * raw_res'./(n * dR')) * (diag(W) .* raw_res - W * zi);
     end
     
 end
+
+
+%% Construct full gradient (if needed)
+
+switch nargout
+    
+    case {0, 1}
+        % Nothing to do, the gradient was not requested
+        
+    case 2
+        % Recommended syntax, with the full gradient as the second output
+        C_grad = [C_grad_lmparam; C_grad_covparam; C_grad_noiseparam];
+        
+    case 3
+        % Old (deprecated) syntax, from a time where linear models were
+        % not allowed to have additional parameters
+        assert (isempty (C_grad_lmparam));
+        C_grad = C_grad_covparam;
+        
+    otherwise
+        stk_error ('Too many input arguments.', 'TooManyInputArgs');
+        
+end % switch
 
 end % function
 
@@ -151,7 +168,7 @@ end % function
 %! TOL_REL = 0.01;
 %! assert (stk_isequal_tolrel (C, C_ref));
 %! assert (stk_isequal_tolrel (dC1, [-0.4205 -0.0077 -0.0046 -0.0459 0.2695]', TOL_REL));
-%! assert (isequal (dC2, []));
+%! assert (isequal (dC2, zeros (0, 1)));
 
 %!test  % with noise variance
 %! model.lognoisevariance = 2*log(0.1);

--- a/param/estim/stk_param_proflik.m
+++ b/param/estim/stk_param_proflik.m
@@ -1,14 +1,21 @@
-% STK_PARAM_RELIK computes the restricted likelihood of a model given data
+% STK_PARAM_PROFLIK computes the profile log-likelihood
 %
-% CALL: C = stk_param_relik (MODEL, XI, ZI)
+% CALL: C = stk_param_proflik (MODEL, XI, ZI)
 %
-%   computes the value C of the opposite of the restricted likelihood criterion
-%   for the MODEL given the data (XI, ZI).
+%   computes the value C of the opposite of the profile log-likelihood
+%   of the MODEL given the data (XI, ZI).
 %
-% CALL: [C, C_GRAD] = stk_param_relik (MODEL, XI, ZI)
+% CALL: [C, C_GRAD] = stk_param_proflik (MODEL, XI, ZI)
 %
 %   also returns the gradient C_GRAD of C with respect to all the
 %   optimizable parameters of the model.
+%
+% REMARK
+%
+%   This is the "first" profile log-likelihood, obtained by maximizing
+%   the log-likelihood with respect to the coefficients of the linear
+%   model.  It still depends on the variance parameter, though (if there
+%   is one).
 %
 % EXAMPLE: see paramestim/stk_param_estim.m
 
@@ -40,7 +47,7 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [C, C_grad, C_grad_noiseparam] = stk_param_relik (model, xi, zi)
+function [C, C_grad, C_grad_noiseparam] = stk_param_proflik (model, xi, zi)
 
 zi = double (zi);
 
@@ -57,7 +64,8 @@ NOISEPRIOR = isfield (model, 'noiseprior');
 
 if (nargout >= 2) || LMPRIOR
     % Parameters of the linear model
-    lmparam_size = length (stk_get_optimizable_parameters (model.lm));
+    lmparam = stk_get_optimizable_parameters (model.lm);
+    lmparam_size = length (lmparam);
 end
 
 if (nargout >= 2) || PARAMPRIOR
@@ -78,50 +86,34 @@ end
 %% Compute the (opposite of) the restricted log-likelihood
 
 [K, P] = stk_make_matcov (model, xi);
-q = size (P, 2);
-simple_kriging = (q == 0);
+simple_kriging = (size (P, 2) == 0);
 
 % Choleski factorization: K = U' * U, with upper-triangular U
 [U, epsi] = stk_cholcov (K);
+UT_TRANSA = struct ('UT', true, 'TRANSA', true);  % Options for linsolve
 if (~ isnoisy) && (epsi > 0)
     stk_assert_no_duplicates (xi);
 end
 
+% Suffix _tilde for (U')^{-1} * ...
+zi_tilde = linsolve (U, zi, UT_TRANSA);
+
 if ~ simple_kriging
-    
-    % Construct a "filtering matrix" A = W'
-    [Q, R_ignored] = qr (P);  %#ok<NASGU> %the second argument *must* be here
-    W = Q(:, (q+1):n);
-    
-    % Compute G = W' * K * W, the covariance matrix of filtered observations
-    M = U * W;
-    G = (M') * M;
-    
-    % Check if G is (at least close to) symmetric
-    Delta = G - G';  s = sqrt (diag (G));
-    if any (abs (Delta) > eps * (s * s'))
-        warning ('STK:stk_param_relik:NumericalAccuracyProblem', ...
-            'The computation of G = W'' * K * W is inaccurate.');
-        G = 0.5 * (G + G');  % Make it at least symmetric
-    end
-    
-    % Cholesky factorization: G = U' * U, with upper-triangular U
-    U = stk_cholcov (G);
-end
-
-% Compute log (det (G)) using the Cholesky factor
-ldetWKW = 2 * sum (log (diag (U)));
-
-% Compute (W' yi)' * G^(-1) * (W' yi) as v' * v, with v = U' \ (W' * yi)
-if simple_kriging
-    yyi = zi;
+    P_tilde = linsolve (U, P, UT_TRANSA);
+    beta = (P_tilde' * P_tilde) \ (P_tilde' * zi_tilde);
+    % yi = zi - P * beta;
+    yi_tilde = zi_tilde - P_tilde * beta;
 else
-    yyi = W' * zi;
+    yi_tilde = zi_tilde;
 end
-v = linsolve (U, yyi, struct ('UT', true, 'TRANSA', true));
-attache = sum (v .^ 2);
 
-C = 0.5 * ((n - q) * log(2 * pi) + ldetWKW + attache);
+% Compute log (det (K)) using the Cholesky factor
+ldetK = 2 * sum (log (diag (U)));
+
+% Compute yi' * K^(-1) * yi
+attache = sum (yi_tilde .^ 2);
+
+C = 0.5 * (n * log(2 * pi) + ldetK + attache);
 
 
 %% Add priors
@@ -139,43 +131,44 @@ end
 
 if nargout >= 2
     
+    % Compute K^(-1) from the Cholesky factor
     if exist ('OCTAVE_VERSION', 'builtin') == 5
-        % Octave remembers that U is upper-triangular and automatically picks
-        % the appropriate algorithm.  Cool.
-        if simple_kriging
-            F = inv (U');
-        else
-            F = (U') \ (W');
-        end
+        K_inv = chol2inv (U);  % = K^(-1)
     else
-        % Apparently Matlab does not automatically leverage the fact that U is
-        % upper-triangular.  Pity.  We have to call linsolve explicitely, then.
-        if simple_kriging
-            F = linsolve (U, eye (n), struct ('UT', true, 'TRANSA', true));
-        else
-            F = linsolve (U, W', struct ('UT', true, 'TRANSA', true));
-        end
+        % Matlab does not have chol2inv
+        % TODO: Write a mex to call LAPACK's dpotri
+        F = linsolve (U, eye (n), UT_TRANSA);
+        K_inv = F' * F;  % = K^(-1)
     end
-    H = F' * F;  % = W * G^(-1) * W'
     
-    z = H * zi;
+    w = linsolve (U, yi_tilde, struct ('UT', true));
     
     % Gradient wrt parameters of the linear model
+    C_grad_lmparam = zeros (lmparam_size, 1);
     if lmparam_size > 0
-        stk_error (['stk_param_relik should not be used to estimate ' ...
-            'hyper-parameters of the linear model.'], ...
-            'InappropriateReLik');
+        lm_ = model.lm;
+        for diff = 1:lmparam_size
+            [V, lm_] = stk_lm_diff (lm_, xi, diff);
+            C_grad_lmparam(diff) = - 2 * w' * V * beta;
+        end
+        if LMPRIOR
+            % FIXME: Implement!
+            stk_error ('LMPRIOR is not implemented yet.', ...
+                'NotImplemented');  %#ok<UNRCH>
+        end
     end
     
     % Gradient wrt parameters of the covariance function
     C_grad_covparam = zeros (covparam_size, 1);
-    for diff = 1:covparam_size
-        V = feval (model.covariance_type, model.param, xi, xi, diff);
-        C_grad_covparam(diff) = 1/2 * (sum (sum (H .* V)) - z' * V * z);
-    end
-    if PARAMPRIOR
-        C_grad_covparam = C_grad_covparam ...
-            - stk_distrib_logpdf_grad (model.prior, covparam);
+    if covparam_size > 0
+        for diff = 1:covparam_size
+            V = feval (model.covariance_type, model.param, xi, xi, diff);
+            C_grad_covparam(diff) = 1/2 * (sum (sum (K_inv .* V)) - w' * V * w);
+        end
+        if PARAMPRIOR
+            C_grad_covparam = C_grad_covparam ...
+                - stk_distrib_logpdf_grad (model.prior, covparam);
+        end
     end
     
     % Gradient wrt parameters of the noise model
@@ -183,7 +176,7 @@ if nargout >= 2
     if noiseparam_size > 0
         for diff = 1:noiseparam_size
             V = stk_covmat_noise (model, xi, [], diff);
-            C_grad_noiseparam(diff) = 1/2 * (sum (sum (H .* V)) - z' * V * z);
+            C_grad_noiseparam(diff) = 1/2 * (sum (sum (K_inv .* V)) - w' * V * w);
         end
         if NOISEPRIOR
             C_grad_noiseparam = C_grad_noiseparam ...
@@ -203,11 +196,12 @@ switch nargout
         
     case 2
         % Recommended syntax, with the full gradient as the second output
-        C_grad = [C_grad_covparam; C_grad_noiseparam];
+        C_grad = [C_grad_lmparam; C_grad_covparam; C_grad_noiseparam];
         
     case 3
         % Old (deprecated) syntax, from a time where linear models were
         % not allowed to have additional parameters
+        assert (isempty (C_grad_lmparam));
         C_grad = C_grad_covparam;
         
     otherwise
@@ -275,15 +269,13 @@ end % function
 %! DELTA = 1e-6;
 %!
 %! model = stk_model ('stk_materncov52_iso', DIM);
-%! model.param = [1 1];
-%!
 %! xi = stk_sampling_halton_rr2 (NI, DIM, BOX);
 %! zi = stk_feval (f, xi);
 %!
-%! for range = [0.3 2 10]
-%!     model.param(2) = - log (range);
-%!     for diff = 1:2
-%!         assert (stk_test_critgrad ...
-%!             (@stk_param_relik, model, xi, zi, diff, 1e-6));
-%!     end
-%! end
+%! model.param = [1 1];
+%! [C1 dC] = stk_param_relik (model, xi, zi);
+%!
+%! model.param = model.param + DELTA * [0 1];
+%! C2 = stk_param_relik (model, xi, zi);
+%!
+%! assert (stk_isequal_tolrel (dC(2), (C2 - C1) / DELTA, TOL_REL));

--- a/param/estim/stk_param_proflik.m
+++ b/param/estim/stk_param_proflik.m
@@ -100,7 +100,9 @@ zi_tilde = linsolve (U, zi, UT_TRANSA);
 
 if ~ simple_kriging
     P_tilde = linsolve (U, P, UT_TRANSA);
-    beta = (P_tilde' * P_tilde) \ (P_tilde' * zi_tilde);
+    [Q,R] = qr(P_tilde);
+    beta = R\(Q'*zi_tilde);
+
     % yi = zi - P * beta;
     yi_tilde = zi_tilde - P_tilde * beta;
 else


### PR DESCRIPTION
Avoiding the normal equation (which squares the condition number) should improve the numerical stability. Eventually, this could be merged into the master-branch, too. 